### PR TITLE
Update runner tag

### DIFF
--- a/.github/workflows/top.yml
+++ b/.github/workflows/top.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release:
     name: GitHub Active Users
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
By a chance, I saw this error from the workflow
> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101Show more
--

So, just update to another OS version for the runner