### PR TITLE
ci: use Node.js 20 for GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
### Motivation
- The GitHub Pages deploy job failed at `yarn install` due to a Node engine mismatch reported as `Expected version ">=20.0". Got "18.20.8"`. 
- Align the workflow runtime with `@docusaurus/core@3.10.0` which requires Node `>=20` so dependency installation and build can succeed.

### Description
- Updated `.github/workflows/deploy.yml` to change `actions/setup-node@v4` `node-version` from `18` to `20`.
- Committed the workflow change so GitHub Actions will run the deploy job on Node.js 20.

### Testing
- Applied the patch to `.github/workflows/deploy.yml` successfully using the automated patch tool. (succeeded)
- Verified the diff with `git diff -- .github/workflows/deploy.yml` which shows `node-version: 18` -> `node-version: 20`. (succeeded)
- Committed the change via `git commit` and confirmed the commit was created. (succeeded)
- Inspected the updated file lines with `nl -ba .github/workflows/deploy.yml` to confirm the new Node version is present. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf8c566a88328a4f2ca799328575e)